### PR TITLE
Return value token rather than name

### DIFF
--- a/addon/components/type-ahead.js
+++ b/addon/components/type-ahead.js
@@ -112,9 +112,10 @@ export default Ember.TextField.extend({
         run.bind(this, (e, obj) => {
           this.set('selection', obj);
 
-          let name = this.get('selection.name');
-          if (name) {
-            this.sendAction('onSelectAction', name);
+          let valueToken = this.get('valueToken');
+          let value = this.get(`selection.${valueToken}`);
+          if (value) {
+            this.sendAction('onSelectAction', value);
           }
         })
       );


### PR DESCRIPTION
If the passed in content didn't have a `name` property, the `onSelectAction` would never fire. It seems like returning the valueToken makes more sense here.
