### PR TITLE
allow vanilla Handlebars to not be loaded/function templates

### DIFF
--- a/addon/components/type-ahead.js
+++ b/addon/components/type-ahead.js
@@ -7,6 +7,18 @@ const {
   run
 } = Ember;
 
+function compile(stringOrFunction) {
+  if (typeof stringOrFunction === 'function') {
+    return stringOrFunction;
+  }
+
+  if (typeof Handlebars !== 'undefined') {
+    return Handlebars.compile(stringOrFunction);
+  }
+
+  return stringOrFunction;
+}
+
 export default Ember.TextField.extend({
   classNames: ['form-control'],
   limit: 5,
@@ -32,21 +44,21 @@ export default Ember.TextField.extend({
               cb(this._filterContent(query, 'value', this.get('tokenContent')));
             }),
             templates: {
-              suggestion: Handlebars.compile(this.get('suggestionTemplate')),
+              suggestion: compile(this.get('suggestionTemplate')),
               footer: run.bind(this, (object) => {
                 var footerTemplate = this.get('footerTemplate');
                 var emptyFooterTemplate = this.get('emptyFooterTemplate');
 
                 if (object.isEmpty && emptyFooterTemplate) {
-                  return Handlebars.compile(emptyFooterTemplate);
+                  return compile(emptyFooterTemplate);
                 }
 
                 if (footerTemplate) {
-                  return Handlebars.compile(footerTemplate);
+                  return compile(footerTemplate);
                 }
               }),
               empty: run.bind(this, () => {
-                return Handlebars.compile(this.get('emptyTemplate'));
+                return compile(this.get('emptyTemplate'));
               })
             }
           }
@@ -86,21 +98,21 @@ export default Ember.TextField.extend({
             cb(this._filterContent(query, this.get('valueToken'), this.get('content')));
           }),
           templates: {
-            suggestion: Handlebars.compile(this.get('suggestionTemplate')),
+            suggestion: compile(this.get('suggestionTemplate')),
             footer: run.bind(this, (object) => {
               var footerTemplate = this.get('footerTemplate');
               var emptyFooterTemplate = this.get('emptyFooterTemplate');
 
               if (object.isEmpty && emptyFooterTemplate) {
-                return Handlebars.compile(emptyFooterTemplate);
+                return compile(emptyFooterTemplate);
               }
 
               if (footerTemplate) {
-                return Handlebars.compile(footerTemplate);
+                return compile(footerTemplate);
               }
             }),
             empty: run.bind(this, () => {
-              return Handlebars.compile(this.get('emptyTemplate'));
+              return compile(this.get('emptyTemplate'));
             })
           }
         }
@@ -161,9 +173,9 @@ export default Ember.TextField.extend({
       return exactRegex.test(Ember.get(thing, valueKey));
     });
 
-    const fuzzyMatches =  content.filter((thing) => {
+    const fuzzyMatches =  Ember.A(content.filter((thing) => {
       return fuzzyRegex.test(Ember.get(thing, valueKey));
-    });
+    }));
 
     return exactMatches.concat(fuzzyMatches.removeObject(exactMatches[0]));
   },

--- a/addon/components/type-ahead.js
+++ b/addon/components/type-ahead.js
@@ -7,18 +7,6 @@ const {
   run
 } = Ember;
 
-function compile(stringOrFunction) {
-  if (typeof stringOrFunction === 'function') {
-    return stringOrFunction;
-  }
-
-  if (typeof Handlebars !== 'undefined') {
-    return Handlebars.compile(stringOrFunction);
-  }
-
-  return stringOrFunction;
-}
-
 export default Ember.TextField.extend({
   classNames: ['form-control'],
   limit: 5,
@@ -44,21 +32,21 @@ export default Ember.TextField.extend({
               cb(this._filterContent(query, 'value', this.get('tokenContent')));
             }),
             templates: {
-              suggestion: compile(this.get('suggestionTemplate')),
+              suggestion: this.get('suggestionTemplate'),
               footer: run.bind(this, (object) => {
                 var footerTemplate = this.get('footerTemplate');
                 var emptyFooterTemplate = this.get('emptyFooterTemplate');
 
                 if (object.isEmpty && emptyFooterTemplate) {
-                  return compile(emptyFooterTemplate);
+                  return emptyFooterTemplate;
                 }
 
                 if (footerTemplate) {
-                  return compile(footerTemplate);
+                  return footerTemplate;
                 }
               }),
               empty: run.bind(this, () => {
-                return compile(this.get('emptyTemplate'));
+                return this.get('emptyTemplate');
               })
             }
           }
@@ -98,21 +86,21 @@ export default Ember.TextField.extend({
             cb(this._filterContent(query, this.get('valueToken'), this.get('content')));
           }),
           templates: {
-            suggestion: compile(this.get('suggestionTemplate')),
+            suggestion: this.get('suggestionTemplate'),
             footer: run.bind(this, (object) => {
               var footerTemplate = this.get('footerTemplate');
               var emptyFooterTemplate = this.get('emptyFooterTemplate');
 
               if (object.isEmpty && emptyFooterTemplate) {
-                return compile(emptyFooterTemplate);
+                return emptyFooterTemplate;
               }
 
               if (footerTemplate) {
-                return compile(footerTemplate);
+                return footerTemplate;
               }
             }),
             empty: run.bind(this, () => {
-              return compile(this.get('emptyTemplate'));
+              return this.get('emptyTemplate');
             })
           }
         }

--- a/tests/integration/components/type-ahead-test.js
+++ b/tests/integration/components/type-ahead-test.js
@@ -1,5 +1,8 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
+import Ember from 'ember';
+
+const { run } = Ember;
 
 moduleForComponent('type-ahead', 'Integration | Component | type ahead', {
   integration: true
@@ -16,3 +19,43 @@ test('it renders', function(assert) {
   assert.equal(this.$().text().trim(), '');
 
 });
+
+test('works if handlebars is not available in the global namespace and functions are passed', function(assert) {
+  var Hbars = window.Handlebars;
+  delete window.Handlebars;
+
+  this.set('suggestionTemplate', function({name}) {
+    return `<p>${name}!</p>`;
+  });
+
+  this.set('footerTemplate', function() {
+    return `<div id='footer'>ZOMG A FOOTER</div>`;
+  });
+
+  this.set('emptyTemplate', function() {
+    return `<div id='empty'><p>Empty :(</p></div>`;
+  });
+
+  this.set('content', ['abc', 'def', 'ghi'].map(val => ({name: val})));
+
+  try {
+    this.render(hbs`{{type-ahead displayKey='name' emptyTemplate=emptyTemplate footerTemplate=footerTemplate valueToken='name' suggestionTemplate=suggestionTemplate content=content}}`);
+
+    run(() => {
+      this.$('.tt-input').val('NO MATCHES!').trigger('input');
+    });
+    assert.equal(this.$().text(), 'Empty :(', 'renders empty template from function');
+
+    run(() => {
+      this.$('.tt-input').val('abc').trigger('input');
+    });
+
+    assert.equal(this.$('.tt-suggestion').length, 1, 'onlys shows relevant result');
+    assert.equal(this.$('.tt-suggestion').text().trim(), 'abc!', 'renders suggestion template from function');
+
+    assert.equal(this.$('#footer').text().trim(), 'ZOMG A FOOTER', 'renders footer template from function');
+  } finally {
+    window.Handlebars = Hbars;
+  }
+});
+


### PR DESCRIPTION
The `footerTemplate/emptyTemplate/suggestionTemplate` can now take
functions instead of Handlebars/string templates. This allows an app to
not have to load vanilla Handlebars.js. Not loading vanilla Handlebars
loads about 12k less javascript in a production build.